### PR TITLE
Move to CircleCI REST API v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The action to get the build number given a VCS revision and a project name.
 Usage:
 
 ```bash
-st2 run circle_ci.get_build_number project=<project> vcs_revision=<sha>
+st2 run circle_ci.get_build_number project=<project> vcs_type=github username=<username> vcs_revision=<sha>
 ```
 
 ### Wait until build finishes - ```wait_until_build_finishes```
@@ -24,7 +24,7 @@ the action fails if the build didn't complete.
 Usage:
 
 ```bash
-st2 run circle_ci.wait_until_build_finishes project=<project> build_number=<build> wait_timeout=<timeout>
+st2 run circle_ci.wait_until_build_finishes project=<project> vcs_type=github username=<username> build_num=<build> wait_timeout=<timeout>
 ```
 
 ### Get build info -  ```get_build_info```
@@ -34,7 +34,7 @@ The action to get the information of a build given a project name and build numb
 Usage:
 
 ```bash
-st2 run circle_ci.get_build_info project=<project> build_num=<build_num>
+st2 run circle_ci.get_build_info project=<project> vcs_type=github username=<username> build_num=<build_num>
 ```
 
 ### Run build -  ```run_build```
@@ -44,11 +44,11 @@ The action to run a build given a project name and branch. Default branch name i
 Usage:
 
 ```bash
-st2 run circle_ci.run_build project=<project> branch=<branch_name>
+st2 run circle_ci.run_build project=<project> vcs_type=github username=<username> branch=<branch_name>
 OR
-st2 run circle_ci.run_build project=<project> tag=<tag_name>
+st2 run circle_ci.run_build project=<project> vcs_type=github username=<username> tag=<tag_name>
 OR
-st2 run circle_ci.run_build project=<project> vcs_revision=<sha>
+st2 run circle_ci.run_build project=<project> vcs_type=github username=<username> vcs_revision=<sha>
 ```
 
 ### Retry build -  ```retry_build```
@@ -58,7 +58,7 @@ The action to retry a build given a project name and build number.
 Usage:
 
 ```bash
-st2 run circle_ci.retry_build project=<project> build_num=<build_num>
+st2 run circle_ci.retry_build project=<project> vcs_type=github username=<username> build_num=<build_num>
 ```
 
 ### Cancel build -  ```cancel_build```
@@ -68,7 +68,7 @@ The action to cancel a build given a project name and build number.
 Usage:
 
 ```bash
-st2 run circle_ci.cancel_build project=<project> build_num=<build_num>
+st2 run circle_ci.cancel_build project=<project> vcs_type=github username=<username> build_num=<build_num>
 ```
 
 ## Configuration

--- a/actions/cancel_build.py
+++ b/actions/cancel_build.py
@@ -5,11 +5,11 @@ from lib.action import CircleCI
 
 class CancelBuild(CircleCI):
 
-    def run(self, project, build_num):
+    def run(self, project, vcs_type, username, build_num):
         """
         ReRun a specific build in project.
         """
-        path = 'project/%s/%s/cancel' % (project, build_num)
+        path = 'project/%s/%s/%s/%s/cancel' % (vcs_type, username, project, build_num)
 
         response = self._perform_request(
             path, method='POST'

--- a/actions/cancel_build.yaml
+++ b/actions/cancel_build.yaml
@@ -9,6 +9,18 @@ parameters:
     type: string
     description: Name of project in circle ci.
     required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
   build_num:
     type: integer
     description: Build number from circle CI.

--- a/actions/get_build_info.py
+++ b/actions/get_build_info.py
@@ -5,11 +5,11 @@ from lib.action import CircleCI
 
 class GetBuildInfoAction(CircleCI):
 
-    def run(self, project, build_num):
+    def run(self, project, vcs_type, username, build_num):
         """
         Get build number for a SHA in project.
         """
-        path = 'project/%s/%s' % (project, build_num)
+        path = 'project/%s/%s/%s/%s' % (vcs_type, username, project, build_num)
 
         response = self._perform_request(
             path, method='GET'

--- a/actions/get_build_info.yaml
+++ b/actions/get_build_info.yaml
@@ -9,6 +9,18 @@ parameters:
     type: string
     description: Name of project in circle ci.
     required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
   build_num:
     type: integer
     description: Build number from circle CI.

--- a/actions/get_build_number.py
+++ b/actions/get_build_number.py
@@ -5,11 +5,11 @@ from lib.action import CircleCI
 
 class GetBuildNumberAction(CircleCI):
 
-    def run(self, vcs_revision, project, search_limit=10):
+    def run(self, project, vcs_type, username, vcs_revision, search_limit=10):
         """
         Get build number for a SHA in project.
         """
-        path = 'project/' + project
+        path = 'project/%s/%s/%s' % (vcs_type, username, project)
 
         response = self._perform_request(
             path, method='GET',

--- a/actions/get_build_number.yaml
+++ b/actions/get_build_number.yaml
@@ -4,13 +4,25 @@ description: Get build number for given SHA.
 enabled: true
 entry_point: get_build_number.py
 parameters:
-  vcs_revision:
-    type: string
-    description: Commit SHA/revision (usually github SHA).
-    required: true
   project:
     type: string
     description: Name of project in circle ci.
+    required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
+  vcs_revision:
+    type: string
+    description: Commit SHA/revision (usually github SHA).
     required: true
   search_limit:
     type: number

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -5,7 +5,7 @@ import requests
 from st2actions.runners.pythonrunner import Action
 
 BASE_API_URL = 'https://circleci.com/api'
-API_VERSION = 'v1'
+API_VERSION = 'v1.1'
 API_URL = '%s/%s/' % (BASE_API_URL, API_VERSION)
 HEADER_ACCEPT = 'application/json'
 HEADER_CONTENT_TYPE = 'application/json'

--- a/actions/retry_build.py
+++ b/actions/retry_build.py
@@ -5,11 +5,11 @@ from lib.action import CircleCI
 
 class RetryBuild(CircleCI):
 
-    def run(self, project, build_num):
+    def run(self, project, vcs_type, username, build_num):
         """
         ReRun a specific build in project.
         """
-        path = 'project/%s/%s/retry' % (project, build_num)
+        path = 'project/%s/%s/%s/%s/retry' % (vcs_type, username, project, build_num)
 
         response = self._perform_request(
             path, method='POST'

--- a/actions/retry_build.yaml
+++ b/actions/retry_build.yaml
@@ -9,6 +9,18 @@ parameters:
     type: string
     description: Name of project in circle ci.
     required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
   build_num:
     type: integer
     description: Build number from circle CI.

--- a/actions/run_build.py
+++ b/actions/run_build.py
@@ -6,22 +6,23 @@ from lib.action import CircleCI
 
 class RunBuild(CircleCI):
 
-    def run(self, project, branch=None, tag=None, vcs_revision=None, build_parameters=None):
+    def run(self, project, vcs_type, username, branch=None,
+            tag=None, vcs_revision=None, build_parameters=None):
         """
         Run build for a SHA in project.
         """
 
         # Add some explicit mutually-exclusive checks.
-        if not(branch or tag or vcs_revision):
+        if not (branch or tag or vcs_revision):
             raise Exception('At least one of branch, tag or vcs_revision should be provided.')
         if (branch and (tag or vcs_revision)) or (tag and vcs_revision):
             raise Exception('Only one of branch, tag or vcs_revision should be provided.')
 
         data = None
         if branch:
-            path = 'project/%s/tree/%s' % (project, branch)
+            path = 'project/%s/%s/%s/tree/%s' % (vcs_type, username, project, branch)
         else:
-            path = 'project/%s' % project
+            path = 'project/%s/%s/%s' % (vcs_type, username, project)
             data = {'tag': tag} if tag else {'revision': vcs_revision}
 
         # build parameters are pass-trhrough to circleci
@@ -35,8 +36,16 @@ class RunBuild(CircleCI):
 
         response = self._perform_request(path, method='POST', data=data)
 
-        if response.status_code != httplib.CREATED:
-            message = response.json().get('message', 'Unknown reason.')
-            raise Exception('Failed to run build : %s' % message)
+        try:
+            result = response.json()
+        except:
+            result = response.content
 
-        return response.json()
+        if response.status_code != httplib.CREATED:
+            raise Exception(
+                'Failed to run build : %s' % (
+                    result.get('message', 'Unknown reason.') if isinstance(result, dict) else result
+                )
+            )
+
+        return result

--- a/actions/run_build.yaml
+++ b/actions/run_build.yaml
@@ -9,6 +9,18 @@ parameters:
     type: string
     description: Name of project in circle ci.
     required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
   branch:
     type: string
     description: Branch to run the build on.

--- a/actions/wait_until_build_finishes.py
+++ b/actions/wait_until_build_finishes.py
@@ -6,11 +6,11 @@ from lib.action import CircleCI
 
 class WaitUntilBuildFinishes(CircleCI):
 
-    def run(self, build_number, project, wait_timeout=600):
+    def run(self, project, vcs_type, username, build_num, wait_timeout=600):
         """
         Get build number for a SHA in project.
         """
-        path = 'project/%s/%s' % (project, build_number)
+        path = 'project/%s/%s/%s/%s' % (vcs_type, username, project, build_num)
 
         start_time = time.time()
         done = False
@@ -20,7 +20,7 @@ class WaitUntilBuildFinishes(CircleCI):
             )
 
             if response.status_code != httplib.OK:
-                msg = ('Build number %s for project ' % build_number +
+                msg = ('Build number %s for project ' % build_num +
                        '%s not found.' % project)
                 raise Exception(msg)
 

--- a/actions/wait_until_build_finishes.yaml
+++ b/actions/wait_until_build_finishes.yaml
@@ -4,13 +4,25 @@ description: Wait until build finishes.
 enabled: true
 entry_point: wait_until_build_finishes.py
 parameters:
-  build_number:
-    type: string
-    description: Circle CI build number.
-    required: true
   project:
     type: string
     description: Name of project in circle ci.
+    required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
+  build_num:
+    type: string
+    description: Circle CI build number.
     required: true
   wait_timeout:
     type: number


### PR DESCRIPTION
CircleCI REST API incremented to v1.1 per https://circleci.com/docs/api/ and project endpoints now required vcs_type and username.