### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.5.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -79,3 +79,7 @@ actions.
 ```yaml
 token: Your Circle CI API access token
 ```
+
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`

--- a/actions/cancel_build.yaml
+++ b/actions/cancel_build.yaml
@@ -1,6 +1,6 @@
 name: cancel_build
 pack: circle_ci
-runner_type: run-python
+runner_type: python-script
 description: Cancel specific build for project.
 enabled: true
 entry_point: cancel_build.py

--- a/actions/get_build_info.yaml
+++ b/actions/get_build_info.yaml
@@ -1,6 +1,6 @@
 name: get_build_info
 pack: circle_ci
-runner_type: run-python
+runner_type: python-script
 description: Get info for build number.
 enabled: true
 entry_point: get_build_info.py

--- a/actions/get_build_number.yaml
+++ b/actions/get_build_number.yaml
@@ -1,5 +1,5 @@
 name: get_build_number
-runner_type: run-python
+runner_type: python-script
 description: Get build number for given SHA.
 enabled: true
 entry_point: get_build_number.py

--- a/actions/retry_build.yaml
+++ b/actions/retry_build.yaml
@@ -1,6 +1,6 @@
 name: retry_build
 pack: circle_ci
-runner_type: run-python
+runner_type: python-script
 description: Retry build for project.
 enabled: true
 entry_point: retry_build.py

--- a/actions/run_build.yaml
+++ b/actions/run_build.yaml
@@ -1,6 +1,6 @@
 name: run_build
 pack: circle_ci
-runner_type: run-python
+runner_type: python-script
 description: Run build for project and branch.
 enabled: true
 entry_point: run_build.py

--- a/actions/wait_until_build_finishes.yaml
+++ b/actions/wait_until_build_finishes.yaml
@@ -1,5 +1,5 @@
 name: wait_until_build_finishes
-runner_type: run-python
+runner_type: python-script
 description: Wait until build finishes.
 enabled: true
 entry_point: wait_until_build_finishes.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
  - circle ci
  - continous integration
  - ci
-version: 0.4.0
+version: 0.5.0
 author: StackStorm dev
 email: support@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.