### PR TITLE
New "run_project_build" action and default config value improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,18 @@
 # Change Log
 
-# 0.5.3
+## 0.5.3
+
+- Default ``host`` configuration option to ``circleci.com``. This way it works out of the
+  box for public / SaaS Circle CI installations.
+
+## 0.5.3
 
 - Ignore payloads with no content (Trigger won't be posted)
 
-# 0.5.2
+## 0.5.2
 
 - Minor linting fixes
 
-# 0.5.0
+## 0.5.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
 # Change Log
 
-## 0.5.3
+## 0.6.0
 
 - Default ``host`` configuration option to ``circleci.com``. This way it works out of the
   box for public / SaaS Circle CI installations.
+
+- Add new ``run_project_build`` action which allows user to trigger a build for all the
+  workflows for a particular project which utilizes workflows version v2.0.
 
 ## 0.5.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
 - Add new ``run_project_build`` action which allows user to trigger a build for all the
   workflows for a particular project which utilizes workflows version v2.0.
 
+- Add new ``wait_until_build_finishes`` action which waits until all the workflows in a
+  specific pipeline finish (API v2.0).
+
 ## 0.5.3
 
 - Ignore payloads with no content (Trigger won't be posted)

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ Usage:
 st2 run circle_ci.get_build_info project=<project> vcs_type=github username=<username> build_num=<build_num>
 ```
 
-### Run build -  ```run_build```
+### Run build - ```run_build```
 
 The action to run a build given a project name and branch. Default branch name is `master`.
+
+NOTE: For Circle CI 2.0 workflows, you should use ``run_project_build`` action which will trigger
+a build for all the workflows in a specific project.
 
 Usage:
 

--- a/actions/cancel_build.py
+++ b/actions/cancel_build.py
@@ -1,7 +1,4 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/cancel_build.py
+++ b/actions/cancel_build.py
@@ -15,7 +15,7 @@ class CancelBuild(CircleCI):
             path, method='POST'
         )
 
-        if response.status_code != http_status.CREATED:
+        if response.status_code != http_status.CREATED:  # pylint: disable=no-member
             raise Exception('Project %s not found.' % project)
 
         return response.json()

--- a/actions/get_build_info.py
+++ b/actions/get_build_info.py
@@ -1,7 +1,4 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/get_build_info.py
+++ b/actions/get_build_info.py
@@ -15,7 +15,7 @@ class GetBuildInfoAction(CircleCI):
             path, method='GET'
         )
 
-        if response.status_code != http_status.OK:
+        if response.status_code != http_status.OK:  # pylint: disable=no-member
             raise Exception('Build %s of project %s not found.' % (build_num, project))
 
         return response.json()

--- a/actions/get_build_number.py
+++ b/actions/get_build_number.py
@@ -16,8 +16,8 @@ class GetBuildNumberAction(CircleCI):
             extra_headers={'limit': str(search_limit)}
         )
 
-        if response.status_code != http_status.OK:
-            raise Exception('Project %s not found.' % project)
+        if response.status_code != http_status.OK:  # pylint: disable=no-member
+            raise Exception('Project %s not found. Response: %s' % (project, response.text))
 
         for build in response.json():
             if build['vcs_revision'] == vcs_revision:

--- a/actions/get_build_number.py
+++ b/actions/get_build_number.py
@@ -1,7 +1,4 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -9,7 +9,7 @@ from st2common.runners.base_action import Action
 
 BASE_API_URL = 'https://circleci.com/api'
 API_VERSION = 'v1.1'
-API_URL = '%s/%s/' % (BASE_API_URL, API_VERSION)
+
 HEADER_ACCEPT = 'application/json'
 HEADER_CONTENT_TYPE = 'application/json'
 
@@ -32,8 +32,8 @@ class CircleCI(Action):
         return headers
 
     def _perform_request(self, path, method, data=None, requires_auth=True,
-                         extra_headers=None):
-        url = API_URL + path
+                         extra_headers=None, api_version='v1.1'):
+        url = '%s/%s/%s' % (BASE_API_URL, api_version, path)
         self.logger.debug('URL: %s', url)
 
         headers = self._get_base_headers()

--- a/actions/list_pipelines.py
+++ b/actions/list_pipelines.py
@@ -1,7 +1,4 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 
@@ -18,7 +15,7 @@ class ListPipelinesAction(CircleCI):
             path, method='GET', api_version='v2'
         )
 
-        if response.status_code != http_status.OK:
+        if response.status_code != http_status.OK:  # pylint: disable=no-member
             raise Exception("Failed to list pipelines: %s" % (str(response.content)))
 
         return response.json()

--- a/actions/list_pipelines.py
+++ b/actions/list_pipelines.py
@@ -1,0 +1,24 @@
+try:  # Python 3
+    from http import HTTPStatus as http_status
+except ImportError:  # Python 2
+    import httplib as http_status
+
+from lib.action import CircleCI
+
+
+class ListPipelinesAction(CircleCI):
+
+    def run(self, project, vcs_type, username, branch=None):
+        path = 'project/%s/%s/%s/pipeline' % (vcs_type, username, project)
+
+        if branch:
+            path += '?branch=%s' % (branch)
+
+        response = self._perform_request(
+            path, method='GET', api_version='v2'
+        )
+
+        if response.status_code != http_status.OK:
+            raise Exception("Failed to list pipelines: %s" % (str(response.content)))
+
+        return response.json()

--- a/actions/list_pipelines.yaml
+++ b/actions/list_pipelines.yaml
@@ -1,0 +1,27 @@
+name: list_pipelines
+pack: circle_ci
+runner_type: python-script
+description: List all the available pipelines (API v2).
+enabled: true
+entry_point: list_pipelines.py
+parameters:
+  project:
+    type: string
+    description: Name of project in circle ci.
+    required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
+  branch:
+    type: string
+    description: Optional branch name to filter the pipelines.
+    required: false

--- a/actions/retry_build.py
+++ b/actions/retry_build.py
@@ -1,7 +1,4 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/retry_build.py
+++ b/actions/retry_build.py
@@ -15,7 +15,7 @@ class RetryBuild(CircleCI):
             path, method='POST'
         )
 
-        if response.status_code != http_status.CREATED:
+        if response.status_code != http_status.CREATED:  # pylint: disable=no-member
             raise Exception('Project %s not found.' % project)
 
         return response.json()

--- a/actions/run_build.py
+++ b/actions/run_build.py
@@ -1,8 +1,6 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
 import json
+
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 
@@ -44,10 +42,10 @@ class RunBuild(CircleCI):
         except ValueError:
             result = response.content
 
-        if response.status_code != http_status.CREATED:
+        if response.status_code != http_status.CREATED:  # pylint: disable=no-member
             raise Exception(
                 'Failed to run build : %s' % (
-                    result.get('message', 'Unknown reason.') if isinstance(result, dict) else result
+                    result.get('message', str(result)) if isinstance(result, dict) else result
                 )
             )
 

--- a/actions/run_project_build.py
+++ b/actions/run_project_build.py
@@ -1,0 +1,51 @@
+try:  # Python 3
+    from http import HTTPStatus as http_status
+except ImportError:  # Python 2
+    import httplib as http_status
+import json
+
+from lib.action import CircleCI
+
+
+class RunProjectBuild(CircleCI):
+
+    def run(self, project, vcs_type, username, branch=None,
+            tag=None, vcs_revision=None):
+        """
+        Run build for a SHA in project.
+        """
+
+        # Add some explicit mutually-exclusive checks.
+        if not (branch or tag or vcs_revision):
+            raise Exception('At least one of branch, tag or vcs_revision should be provided.')
+        if (branch and (tag or vcs_revision)) or (tag and vcs_revision):
+            raise Exception('Only one of branch, tag or vcs_revision should be provided.')
+
+        data = {}
+        if branch:
+            data['branch'] = branch
+        elif tag:
+            data['tag'] = tag
+        elif vcs_revision:
+            data['vcs_revision'] = vcs_revision
+
+        path = 'project/%s/%s/%s/build' % (vcs_type, username, project)
+
+        if data:
+            data = json.dumps(data)
+
+        response = self._perform_request(path, method='POST', data=data)
+
+        try:
+            result = response.json()
+        except ValueError:
+            result = response.content
+
+        if response.status_code not in [http_status.OK, http_status.CREATED]:
+            raise Exception(
+                'Failed to run build : %s' % (
+                    result.get('message', result) if isinstance(result, dict) else result
+                )
+            )
+
+        return result

--- a/actions/run_project_build.py
+++ b/actions/run_project_build.py
@@ -1,8 +1,6 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
 import json
+
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/run_project_build.py
+++ b/actions/run_project_build.py
@@ -39,7 +39,8 @@ class RunProjectBuild(CircleCI):
         except ValueError:
             result = response.content
 
-        if response.status_code not in [http_status.OK, http_status.CREATED]:
+        valid_statuses = [http_status.OK, http_status.CREATED]  # pylint: disable=no-member
+        if response.status_code not in valid_statuses:
             raise Exception(
                 'Failed to run build : %s' % (
                     result.get('message', result) if isinstance(result, dict) else result

--- a/actions/run_project_build.yaml
+++ b/actions/run_project_build.yaml
@@ -1,0 +1,32 @@
+name: run_project_build
+pack: circle_ci
+runner_type: python-script
+description: Run build for project and branch (Circle CI >= 2.0)
+enabled: true
+entry_point: run_project_build.py
+parameters:
+  project:
+    type: string
+    description: Name of project in circle ci.
+    required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
+  branch:
+    type: string
+    description: Branch to run the build on.
+  tag:
+    type: string
+    description: Tag to run the build on.
+  vcs_revision:
+    type: string
+    description: Commit SHA/revision (usually github SHA).

--- a/actions/wait_until_build_finishes.py
+++ b/actions/wait_until_build_finishes.py
@@ -1,8 +1,6 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
 import time
+
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/wait_until_build_finishes.py
+++ b/actions/wait_until_build_finishes.py
@@ -20,7 +20,7 @@ class WaitUntilBuildFinishes(CircleCI):
                 path, method='GET',
             )
 
-            if response.status_code != http_status.OK:
+            if response.status_code != http_status.OK:  # pylint: disable=no-member
                 msg = ('Build number %s for project ' % build_num +
                        '%s not found.' % project)
                 raise Exception(msg)

--- a/actions/wait_until_pipeline_finishes.py
+++ b/actions/wait_until_pipeline_finishes.py
@@ -1,8 +1,6 @@
-try:  # Python 3
-    from http import HTTPStatus as http_status
-except ImportError:  # Python 2
-    import httplib as http_status
 import time
+
+import six.moves.http_client as http_status
 
 from lib.action import CircleCI
 

--- a/actions/wait_until_pipeline_finishes.py
+++ b/actions/wait_until_pipeline_finishes.py
@@ -1,0 +1,80 @@
+try:  # Python 3
+    from http import HTTPStatus as http_status
+except ImportError:  # Python 2
+    import httplib as http_status
+import time
+
+from lib.action import CircleCI
+
+PIPELINE_DONE_STATES = [
+    "errored",
+]
+
+# https://circleci.com/docs/api/v2/#get-a-pipeline-39-s-workflows
+WORKFLOW_DONE_STATES = [
+    "success",
+    "failed",
+    "error",
+    "failing",
+    "canceled",
+    "unauthorized"
+]
+
+
+class WaitUntilPipelineWorkflowsFinish(CircleCI):
+
+    def run(self, project, vcs_type, username, pipeline_num, wait_timeout=600,
+            sleep_interval=10):
+        # Check if pipeline itself has finished (aka there was an error)
+        path = 'project/%s/%s/%s/pipeline/%s' % (vcs_type, username, project, pipeline_num)
+        response = self._perform_request(
+            path, method='GET', api_version='v2'
+        )
+
+        if response.status_code != http_status.OK:
+            raise Exception("Failed to retrieve pipelines: %s" % (str(response.content)))
+
+        data = response.json()
+
+        if data["state"] in PIPELINE_DONE_STATES:
+            print('Pipeline has finished.')
+            return {"status": "failure"}
+
+        pipeline_id = data["id"]
+
+        start_time = time.time()
+        done = False
+
+        # Find all the pipeline workflows and wait for them to finish
+        while not done:
+            path = 'pipeline/%s/workflow' % (pipeline_id)
+            response = self._perform_request(
+                path, method='GET', api_version='v2'
+            )
+
+            all_workflows = response.json()["items"]
+            finished_workflows = [w for w in all_workflows if w["status"] in WORKFLOW_DONE_STATES]
+
+            workflow_names = [w["name"] for w in finished_workflows]
+
+            if len(finished_workflows) >= len(all_workflows):
+                print('All pipeline workflows (%s) have finished' % ', '.join(workflow_names))
+                # On success, we also return overall pipeline status
+
+                succeeded_workflows = [w for w in all_workflows if w["status"] in ["success"]]
+
+                if len(succeeded_workflows) >= len(all_workflows):
+                    status = "success"
+                else:
+                    status = "failure"
+
+                return {"status": status}
+
+            print("%s/%s workflows (%s) finished" % (len(finished_workflows), len(all_workflows),
+                                                     ', '.join(workflow_names)))
+
+            time.sleep(sleep_interval)
+            done = (time.time() - start_time) > wait_timeout
+
+        raise Exception('Pipeline did not complete within %s seconds.' %
+                        wait_timeout)

--- a/actions/wait_until_pipeline_finishes.yaml
+++ b/actions/wait_until_pipeline_finishes.yaml
@@ -1,0 +1,31 @@
+name: wait_until_pipeline_finishes
+runner_type: python-script
+description: Wait until a Circle CI pipeline (aka all the workflows in the pipeline) finish (API v2).
+enabled: true
+entry_point: wait_until_pipeline_finishes.py
+parameters:
+  project:
+    type: string
+    description: Name of project in circle ci.
+    required: true
+  vcs_type:
+    type: string
+    description: Name of version control system.
+    required: true
+    enum:
+        - github
+        - bitbucket
+    default: github
+  username:
+    type: string
+    description: Username in circle ci.
+    required: true
+  pipeline_num:
+    type: string
+    description: Circle CI pipeline number.
+    required: true
+  wait_timeout:
+    type: number
+    description: How long to wait before timing out (in seconds).
+    required: false
+    default: 600

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -9,6 +9,7 @@
     type: "string"
     secret: false
     required: true
+    default: "circleci.com"
   port:
     description: "Circle CI server port."
     type: "integer"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - circle ci
   - continous integration
   - ci
-version: 0.5.3
+version: 0.6.0
 author: StackStorm dev
 email: support@stackstorm.com
 python_versions:

--- a/tests/test_wait_until_build_finishes.py
+++ b/tests/test_wait_until_build_finishes.py
@@ -49,7 +49,7 @@ class WaitUntilBuildFinishesActionTestCase(BaseActionTestCase):
         except Exception as e:
             expected_msg = ('Build did not complete within %s seconds.' %
                             TEST_TIMEOUT)
-            self.assertEqual(expected_msg, e.message)
+            self.assertEqual(expected_msg, str(e))
 
     @responses.activate
     def test_happy_case(self):


### PR DESCRIPTION
This pull request includes two changes:

1. Fix / specify default value for ``host`` config option. This way it works out of the box for public (non on premise enterprise) Circle CI projects

2. Add new ``run_project_build`` action which allows user to trigger a build for all the workflows for a particular project which utilizes workflows v2.

Existing ``run_build`` job doesn't work with new v2.0 workflows.