### PR TITLE
Use Python 3 compatible syntax to get exception message

### DIFF
--- a/tests/test_wait_until_build_finishes.py
+++ b/tests/test_wait_until_build_finishes.py
@@ -49,7 +49,7 @@ class WaitUntilBuildFinishesActionTestCase(BaseActionTestCase):
         except Exception as e:
             expected_msg = ('Build did not complete within %s seconds.' %
                             TEST_TIMEOUT)
-            self.assertEqual(expected_msg, e.message)
+            self.assertEqual(expected_msg, str(e))
 
     @responses.activate
     def test_happy_case(self):


### PR DESCRIPTION
This PR tweaks a test to use syntax that is forward compatible with Python 3. Instead of relying on exceptions having a `message` attribute, we now simply convert the exception to a string. This fixes pack CI.

See this PEP for more information: https://www.python.org/dev/peps/pep-0352/#transition-plan