### PR TITLE
Block deploy on both Python 2 and Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,6 +120,7 @@ workflows:
       - deploy:
           requires:
             - build_and_test_python27
+            - build_and_test_python36
           filters:
             branches:
               only: master


### PR DESCRIPTION
We currently deploy only if the Python 2 tests pass. This blocks until both tests pass. We do advertise both Python 2 and 3 in `pack.yaml`, so Python 3 test failures should fail the build, and therefore block deployment.