### PR TITLE
Fix incorrect error message (ancient copy/paste oversight)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.6.1
+
+- Fix ancient copy/paste error from Travis pack
+
 ## 0.6.0
 
 - Default ``host`` configuration option to ``circleci.com``. This way it works out of the

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -51,7 +51,7 @@ class CircleCI(Action):
             response = requests.put(url, data=data, headers=headers)
 
         if response.status_code in [http_status.FORBIDDEN, http_status.UNAUTHORIZED]:
-            msg = ('Invalid or missing Travis CI auth token. ' +
+            msg = ('Invalid or missing CircleCI auth token. ' +
                    'Make sure you have'
                    'specified valid token in the config file')
             raise Exception(msg)

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - circle ci
   - continous integration
   - ci
-version: 0.6.0
+version: 0.6.1
 author: StackStorm dev
 email: support@stackstorm.com
 python_versions:


### PR DESCRIPTION
The `actions/lib/action.py` file was copied wholesale from the Travis CI pack, but the error message was not updated to indicate that this pack is for CircleCI. This PR fixes that.